### PR TITLE
Fix version 'release', changing it to 'master'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
-go: 
+go:
  - 1.3.3
  - 1.4.2
  - 1.5.1
- - release
+ - 1.7.x
+ - master
  - tip
 
 script:


### PR DESCRIPTION
'release' doesn't seem to work anymore on travis-ci. Not sure when this started happening, but replacing it with 'master' seems to do the trick.

Successful build from this pull request: https://travis-ci.org/adam000/travisci-golang-example/builds/187583125

You can see from one of my personal projects that 'release' does not work: https://travis-ci.org/adam000/goutils/jobs/187567605

Your project came up high on a few of my Google searches, so I thought it might be prudent to update things to be current.